### PR TITLE
Add source and line numbers to default above callback output

### DIFF
--- a/example/simple.py
+++ b/example/simple.py
@@ -18,12 +18,12 @@ def faster_function() -> None:
     time.sleep(0.001)
 
 
-@flat_profile(time_limit=0.3)
+@flat_profile(time_limit=0.3, ignore_builtins=False)
 def example_function(count: int) -> str:
     """Function we are rewriting to time calls."""
     faster_function()
-    for _ in (int(v) for v in range(count)):
-        pass
+    for v in range(count):
+        int(v)
     return slow_function(val=123.45)
 
 

--- a/flat_profiler/__about__.py
+++ b/flat_profiler/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present Daniel Wehr <danwehr@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,12 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Utilities"
 ]
 dependencies = [
-    "recompyle >= 0.2.1, < 0.3.0"
+    "recompyle >= 0.4.1, < 0.5.0"
 ]
 
 [project.urls]
@@ -48,7 +49,7 @@ dependencies = [
 ]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.10", "3.11"]
+python = ["3.10", "3.11", "3.12"]
 
 [tool.hatch.envs.test.scripts]
 test = "pytest {args}"


### PR DESCRIPTION
Resolves #1.

This additional data being captured has slowed down call wrapper a little bit, but not enough to be concerned. Documentation has been updated accordingly.